### PR TITLE
git clone ssh to https change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Node.js module that adds a native interface to Bitcoin Core for querying infor
 ## Install
 
 ```bash
-git clone git@github.com:bitpay/bitcoind.js.git
+git clone https://github.com/bitpay/bitcoind.js.git
 cd bitcoind.js
 npm install
 ```


### PR DESCRIPTION
You can only git clone using ssh if you have ssh keypair and pub key uploaded to github. Otherwise, you will get "Permission denied (publickey)."
it's recommended to use https e.g. git clone https://github.com/bitpay/bitcoind.js.git